### PR TITLE
Refine LeNet training script and documentation

### DIFF
--- a/Deep_project/Mnist/LeNet/Mnist_LeNet.py
+++ b/Deep_project/Mnist/LeNet/Mnist_LeNet.py
@@ -1,153 +1,243 @@
+"""Simple LeNet implementation for MNIST classification.
+
+The script provides a small, configurable training loop that can run on CPU
+or GPU. A few convenience arguments make it easy to sanity‑check the pipeline
+without running a full 10‑epoch training session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+from dataclasses import dataclass, field
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torchvision
-import torch.optim as optim
-import matplotlib.pyplot as plt #数据可视化
-import numpy as np
-from PIL import Image
-from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+from torchvision import transforms
 
-learning_rate = 0.01
-batch_size = 64
-device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
-# 将数据集合下载到指定目录下,这里的transform表示，数据加载时所需要做的预处理操作
-# 加载训练集合
-train_dataset = torchvision.datasets.MNIST(
-    root='.data',
-    train=True,
-    transform=transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Normalize((0.1307,), (0.3081,))
-    ]),  # 转化为tensor且数据标准化注意在FC中我们未做数据增强
-    download=True)
-# 加载测试集合
-test_dataset = torchvision.datasets.MNIST(
-    root='.data',
-    train=False,
-    transform=transforms.Compose([
-        transforms.ToTensor(),
-        transforms.Normalize((0.1307,), (0.3081,))
-    ]),
-    download=True)
 
-train_loader = torch.utils.data.DataLoader(
-    dataset=train_dataset,
-    batch_size=batch_size,  # 一个批次的大小为128张
-    shuffle=True  # 随机打乱
+@dataclass
+class TrainingConfig:
+    """Configuration values controlling training behaviour."""
 
-)
+    epochs: int = 10
+    batch_size: int = 64
+    learning_rate: float = 0.01
+    data_dir: str = ".data"
+    checkpoint_path: str = "LeNet.pth"
+    plot_path: str = "lenet_accuracy.png"
+    seed: int = 42
+    max_train_batches: int | None = None
+    max_eval_batches: int | None = None
+    device: torch.device = field(
+        default_factory=lambda: torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    )
 
-test_loader = torch.utils.data.DataLoader(
-    dataset=test_dataset,
-    batch_size=batch_size,
-    shuffle=True
-)
+
+def set_seed(seed: int) -> None:
+    """Seed python, numpy and torch PRNGs for reproducibility."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
 
 
 class LeNet(nn.Module):
-    # 定义构造方法函数，用来实例化
-    def __init__(self):
-        super(LeNet, self).__init__()  # 5层， 2个卷积层+3个fc全连接层
-        # 1*1*28*28
-        # 第一个卷积层：输入通道数=1，输出通道数=6，卷积核大小=5*5，默认步长=1
-        self.conv1 = nn.Conv2d(in_channels=1, out_channels=6, kernel_size=5)  # 6 * 24 * 24
-        # 第二个卷积层：输入通道数=6，输出通道数=16，卷积核大小=5*5，默认步长=1
-        self.conv2 = nn.Conv2d(in_channels=6, out_channels=16, kernel_size=5)  # 16 * 8 * 8
+    """Minimal LeNet‑5 style network for MNIST."""
 
-        # an affine operation: y = Wx + b
-        self.fc1 = nn.Linear(in_features=16 * 4 * 4, out_features=120)  # 16 * 4 * 4
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(in_channels=1, out_channels=6, kernel_size=5)
+        self.conv2 = nn.Conv2d(in_channels=6, out_channels=16, kernel_size=5)
+        self.fc1 = nn.Linear(in_features=16 * 4 * 4, out_features=120)
         self.fc2 = nn.Linear(in_features=120, out_features=84)
         self.fc3 = nn.Linear(in_features=84, out_features=10)
-        # 第一个全连接层：输入特征数=256，输出特征数=120
-        # 也可以理解成：将256个节点连接到120个节点上
-        # 第三个全连接层：输入特征数=84，输出特征数=10（这10个维度我们作为0-9的标识来确定识别出的是那个数字。）
-        # 也可以理解成：将84个节点连接到10个节点上
 
-    def forward(self, x):
-        # Max pooling over a (2, 2) window
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = F.max_pool2d(F.relu(self.conv1(x)), (2, 2))
         x = F.max_pool2d(F.relu(self.conv2(x)), 2)
-        x = torch.flatten(x, 1)  # flatten all dimensions except the batch dimension
+        x = torch.flatten(x, 1)
         x = F.relu(self.fc1(x))
         x = F.relu(self.fc2(x))
-        x = self.fc3(x)
-        # x = F.log_softmax(x,dim=1) # 这个问题前面FC建模已经说过了 参考官方LeNet
-        return x
+        return self.fc3(x)
 
-def train(epoch):
-    run_loss = 0.0
-    for batch_idx, data in enumerate(train_loader, 0):#循环次数batch_idx的最大循环值 +1 = (MNIST数据集样本总数60000/ BATCH_SIZE )
-        inputs, target = data
-        inputs, target = inputs.to(device), target.to(device)
+
+def get_data_loaders(config: TrainingConfig) -> tuple[DataLoader, DataLoader]:
+    transform = transforms.Compose(
+        [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
+    )
+
+    train_dataset = torchvision.datasets.MNIST(
+        root=config.data_dir, train=True, transform=transform, download=True
+    )
+    test_dataset = torchvision.datasets.MNIST(
+        root=config.data_dir, train=False, transform=transform, download=True
+    )
+
+    train_loader = DataLoader(train_dataset, batch_size=config.batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=config.batch_size, shuffle=False)
+    return train_loader, test_loader
+
+
+def train_one_epoch(
+    model: nn.Module,
+    loader: Iterable,
+    criterion: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    device: torch.device,
+    max_batches: int | None = None,
+) -> float:
+    model.train()
+    running_loss = 0.0
+
+    for batch_idx, (inputs, targets) in enumerate(loader):
+        if max_batches is not None and batch_idx >= max_batches:
+            break
+
+        inputs, targets = inputs.to(device), targets.to(device)
         optimizer.zero_grad()
         outputs = model(inputs)
-        loss = criterion(outputs, target)
-        loss.backward()#反向计算梯度
-        optimizer.step()#优化参数
-        run_loss += loss.item()
-        if batch_idx % 200 == 199:
-            print('[%d, %5d] loss: %.3f' % (epoch + 1, batch_idx + 1, run_loss /200))
-            run_loss = 0.0
+        loss = criterion(outputs, targets)
+        loss.backward()
+        optimizer.step()
+        running_loss += loss.item()
 
-def test():
+        if (batch_idx + 1) % 200 == 0:
+            avg_loss = running_loss / 200
+            print(f"[batch {batch_idx + 1:05d}] loss: {avg_loss:.4f}")
+            running_loss = 0.0
+
+    return running_loss
+
+
+def evaluate(
+    model: nn.Module,
+    loader: Iterable,
+    device: torch.device,
+    max_batches: int | None = None,
+) -> float:
+    model.eval()
     correct = 0
     total = 0
-    with torch.no_grad():#此时已经不需要计算梯度，也不会进行反向传播
-        for data in test_loader:
-            images, labels = data
-            images, labels = images.to(device), labels.to(device) #将数据转移到cuda上
+
+    with torch.no_grad():
+        for batch_idx, (images, labels) in enumerate(loader):
+            if max_batches is not None and batch_idx >= max_batches:
+                break
+
+            images, labels = images.to(device), labels.to(device)
             outputs = model(images)
-            _, predicted = torch.max(outputs.data, dim=1)# 将输出结果概率最大的作为预测值，找到概率最大的下标,输出最大值的索引位置
+            _, predicted = torch.max(outputs.data, dim=1)
             total += labels.size(0)
-            correct += (predicted == labels).sum().item()#正确率累加
-    print('accuracy on test set: %d %% ' % (100 * correct / total))
-    return correct / total
+            correct += (predicted == labels).sum().item()
 
-if __name__ == '__main__':
-    model = LeNet().to(device)
+    accuracy = correct / total if total else 0.0
+    print(f"Accuracy on evaluation set: {accuracy * 100:.2f}%")
+    return accuracy
+
+
+def plot_accuracy(epochs: list[int], accuracies: list[float], output_path: str) -> None:
+    plt.figure()
+    plt.plot(epochs, accuracies, marker="o")
+    plt.title("MNIST on LeNet-5")
+    plt.ylabel("Accuracy")
+    plt.xlabel("Epoch")
+    plt.grid(True)
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+    print(f"Saved accuracy curve to {output_path}")
+
+
+def train_model(config: TrainingConfig) -> None:
+    set_seed(config.seed)
+
+    train_loader, test_loader = get_data_loaders(config)
+    model = LeNet().to(config.device)
     criterion = nn.CrossEntropyLoss()
-    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
-    epoch_list = []
-    acc_list = []
-    for epoch in range(10):
-        train(epoch)
-        acc = test()
-        epoch_list.append(epoch)
-        acc_list.append(acc)
-    plt.plot(epoch_list, acc_list)
-    plt.title("The Mnist on LeNet-5")
-    plt.ylabel('accuracy')
-    plt.xlabel('epoch')
-    plt.show()
-    acc = np.array(acc_list).mean()
-    print(f'Accuracy of the network on the 10000 test images: {acc} %')
-    torch.save(model.state_dict(), 'LeNet.pth')
+    optimizer = torch.optim.Adam(model.parameters(), lr=config.learning_rate)
+
+    epoch_list: list[int] = []
+    acc_list: list[float] = []
+
+    for epoch in range(config.epochs):
+        print(f"\nEpoch {epoch + 1}/{config.epochs}")
+        train_one_epoch(
+            model,
+            train_loader,
+            criterion,
+            optimizer,
+            config.device,
+            max_batches=config.max_train_batches,
+        )
+        accuracy = evaluate(
+            model,
+            test_loader,
+            config.device,
+            max_batches=config.max_eval_batches,
+        )
+        epoch_list.append(epoch + 1)
+        acc_list.append(accuracy)
+
+    plot_accuracy(epoch_list, acc_list, config.plot_path)
+    avg_acc = np.mean(acc_list)
+    print(f"Mean accuracy over {config.epochs} epochs: {avg_acc * 100:.2f}%")
+    torch.save(model.state_dict(), config.checkpoint_path)
+    print(f"Model saved to {config.checkpoint_path}")
 
 
+def parse_args() -> TrainingConfig:
+    parser = argparse.ArgumentParser(description="Train LeNet-5 on MNIST.")
+    parser.add_argument("--epochs", type=int, default=10, help="Number of training epochs.")
+    parser.add_argument("--batch-size", type=int, default=64, help="Batch size for training.")
+    parser.add_argument("--learning-rate", type=float, default=0.01, help="Optimizer learning rate.")
+    parser.add_argument(
+        "--max-train-batches",
+        type=int,
+        default=None,
+        help="Limit the number of batches per epoch (useful for quick checks).",
+    )
+    parser.add_argument(
+        "--max-eval-batches",
+        type=int,
+        default=None,
+        help="Limit the number of evaluation batches (useful for quick checks).",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default=".data",
+        help="Directory where MNIST data will be downloaded.",
+    )
+    parser.add_argument(
+        "--checkpoint-path", type=str, default="LeNet.pth", help="Where to save the trained weights."
+    )
+    parser.add_argument(
+        "--plot-path", type=str, default="lenet_accuracy.png", help="Where to save the accuracy curve."
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for reproducibility.")
+
+    args = parser.parse_args()
+    return TrainingConfig(
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        learning_rate=args.learning_rate,
+        data_dir=args.data_dir,
+        checkpoint_path=args.checkpoint_path,
+        plot_path=args.plot_path,
+        seed=args.seed,
+        max_train_batches=args.max_train_batches,
+        max_eval_batches=args.max_eval_batches,
+    )
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-torch.save(model.state_dict(), 'mlp.pth')
+if __name__ == "__main__":
+    train_model(parse_args())

--- a/README.md
+++ b/README.md
@@ -1,69 +1,67 @@
- 
 # Deep Learning Repository
-此仓库包含关于机器学习、深度学习、计算机视觉、自然语言处理、爬虫等领域的各种项目学习资料和代码。  
-## 📝 Clip
-包含论文解析以及概念整理。  
-## 🚀 Deep Projects
-包含以下深度学习项目和案例： 
-                           
-- 3D Keypoint: 3D 关键点检测
- - Data Preprocessing for NLP: NLP 数据预处理
- - DGCNN: 动态图卷积神经网络
- - ERNerClassification: 实体识别与分类
-- FCOS_Pytorch_Case: FCOS 目标检测 Pytorch 实现
-- Fraud Prediction: 欺诈预测
-- Keras Text Classification: Keras 文本分类
-- Lebert NER: 基于 Lebert 的命名实体识别
-- Mnist: 手写数字识别
-- NER: 命名实体识别
-- Pointnet/Pointnet2: 点云网络
-- Reading Comprehension: 阅读理解
-- RetinaNet: 视网膜网网络
-- Swin: Swin Transformer 
-- T5: Text-to-Text Transfer Transformer
-- Text Generation TF: 基于TensorFlow的文本生成
-- VAE: 变分自编码器
-- YOLOv5: YOLOv5目标检测 + 量化感知训练 + 教师模型 + 剪枝
-## 📚 Deep Learning Notes
-CV Note: 计算机视觉笔记
-## 🌐 GAN
-- WGAN: Wasserstein GAN
-- Improved GAN: 改进的 GAN 模型
-## 📊 Graph Replications
-复现以下图神经网络模型：
- 
-- GAT: 图注意力网络
- - GIN: 图同构网络
-- GraphQ
-- GraphSAGE
-- Label Propagation: 标签传播算法
-- LINE
-- Metapath2Vec
-- MPNN: 消息传递神经网络
-- PinSAGE
-- PyGCN
-- RGCN
-- SDNE
-## 🧮 LLMs
-Large Model Notes: 大模型相关的 50 篇
-## 🕵️ Machine Learning Algorithms
-Fraud Detection: 欺诈检测算法
-## 🔄 ONNX
-- Sklearn ONNX: Sklearn 模型转 ONNX
-- ONNX Runtime: ONNX 模型运行时
--  PNNX: 另一种 ONNX 工具
-## 🛠 Optimization
-Matlab Optimization Implementation: Matlab 优化实现
-## 🕸 Spider
-- Requests
-- Scrapy
-## 📊 SQL
-SQL Notes: SQL 笔记
-## 🤖 Transformer
-Complete Guide to Transformers: Transformer 模型完全解读
-## langchain 
 
-## 结束语
-感谢您访问此仓库！我们希望您能在这里找到对您的学习和研究有价值的资源。如果您有任何反馈或建议，请通过 Issue 或 Pull Requests 与我们分享。希望这些资源能助您一臂之力，共同推动深度学习和机器学习领域的发展。
+此仓库收录了机器学习、深度学习、计算机视觉、自然语言处理和爬虫等方向的代码示例与学习资料，便于快速检索和复现。
 
-请继续关注更新，祝您探索愉快
+## 项目导航
+- **Clip**：论文解析与核心概念整理。
+- **Deep Projects**：
+  - 3D Keypoint：3D 关键点检测
+  - Data Preprocessing for NLP：NLP 数据预处理
+  - DGCNN：动态图卷积神经网络
+  - ERNerClassification：实体识别与分类
+  - FCOS_Pytorch_Case：FCOS 目标检测 Pytorch 实现
+  - Fraud Prediction：欺诈预测
+  - Keras Text Classification：Keras 文本分类
+  - Lebert NER：基于 Lebert 的命名实体识别
+  - Mnist：LeNet、AlexNet、GoogLeNet 等模型实现
+  - NER：命名实体识别
+  - Pointnet/Pointnet2：点云网络
+  - Reading Comprehension：阅读理解
+  - RetinaNet：单阶段目标检测
+  - Swin：Swin Transformer
+  - T5：Text-to-Text Transfer Transformer
+  - Text Generation TF：TensorFlow 文本生成
+  - VAE：变分自编码器
+  - YOLOv5：目标检测 + 量化感知训练 + 教师模型 + 剪枝
+- **Deep Learning Notes**：计算机视觉相关笔记。
+- **GAN**：WGAN、Improved GAN 等生成对抗网络实现。
+- **Graph Replications**：GAT、GIN、GraphSAGE、Label Propagation、LINE、Metapath2Vec、MPNN、PinSAGE、PyGCN、RGCN、SDNE 等图模型复现。
+- **LLMs**：大模型相关的 50 余篇资料。
+- **Machine Learning Algorithms**：欺诈检测等传统机器学习算法。
+- **ONNX**：Sklearn ONNX 转换、ONNX Runtime、PNNX 等工具示例。
+- **Optimization**：Matlab 优化实现。
+- **Spider**：Requests 与 Scrapy 示例。
+- **SQL**：SQL 学习笔记。
+- **Transformer**：Transformer 模型解读。
+- **LangChain**：LangChain 相关资料。
+
+## 示例：在 MNIST 上训练 LeNet
+位于 `Deep_project/Mnist/LeNet/Mnist_LeNet.py` 的脚本提供了可配置的训练与评估流程，支持 GPU/CPU 自动切换，并允许通过命令行快速做小批量验证。
+
+### 依赖
+- Python 3.10+
+- PyTorch、TorchVision
+- Matplotlib、NumPy
+
+使用 pip 安装核心依赖：
+
+```bash
+pip install torch torchvision matplotlib numpy
+```
+
+### 快速运行
+下载数据并训练 1 个 epoch，同时限制训练/验证批次数以快速验证流程：
+
+```bash
+python Deep_project/Mnist/LeNet/Mnist_LeNet.py \
+  --epochs 1 \
+  --max-train-batches 5 \
+  --max-eval-batches 2
+```
+
+脚本会输出每轮准确率，并在运行结束后保存：
+- 训练曲线：`lenet_accuracy.png`
+- 模型权重：`LeNet.pth`
+
+## 反馈
+欢迎通过 Issue 或 Pull Request 提出建议与改进，让这些资源更好地服务学习与研究。


### PR DESCRIPTION
## Summary
- refactor the MNIST LeNet script with a configurable training loop, seeding, and optional batch limits for quick checks
- add accuracy plotting and clean CLI options for saving checkpoints and data locations
- restructure the repository README with clearer project navigation and LeNet usage instructions

## Testing
- python -m compileall Deep_project/Mnist/LeNet/Mnist_LeNet.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69363645f03c8321a3aa67a456b65018)